### PR TITLE
Changes to make script installable.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,14 +9,15 @@ if [ -z "$sourced_functions_file" ]; then
 	if [ -s "$shellc_path/functions_file.sh" ]; then
 		. "$shellc_path/functions_file.sh"
 	else
-		wget https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_file.sh
-		. functions_file.sh
+		#We need this to properly include (file not found otherwise)
+		wget -P /tmp/ https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_file.sh
+		. /tmp/functions_file.sh
 	fi
 	if [ -s "$shellc_path/functions_min.sh" ]; then
 		. "$shellc_path/functions_min.sh"
 	else
-		wget https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_min.sh
-		. functions_min.sh
+		wget -P /tmp/ https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_min.sh
+		. /tmp/functions_min.sh
 	fi
 fi
 
@@ -52,15 +53,32 @@ echo ""		# (optional) move to a new line
 if ! [[ $REPLY =~ ^[Nn]$ ]]; then
 	tmp=/tmp/gagvdotfiles
 	echo "Downloading repo"
+	#Delete a previous dowloaded gagvdotfiles
+	if [ -d $tmp ]; then
+		rm -rf $tmp
+	fi
+
 	github_clone_donwload_f andresgomezvidal/dotfiles "$tmp"
 	echo "Moving repo"
 	for i in "$tmp"/{,.}*
 	do
-		mv -i "$i" "$ori"
+		#Copy recursive so as not to ask every time to overwrite
+		base=`basename $i`
+		cp -rf "$i" "$ori/$base"
 	done
 fi
 cd "$ori"
 
+#Sometimes the script doesn't include well the functions so we do this hax.
+if [ -n $(type -t ln_cp_bak_question_f) ]; then
+	#Deactivate this to include properly
+	sourced_functions_file=false
+	wget -P /tmp/ https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_file.sh
+	. /tmp/functions_file.sh
+	wget -P /tmp/ https://raw.githubusercontent.com/andresgomezvidal/zsh_conf/master/custom/functions_min.sh
+	. /tmp/functions_min.sh
+	sourced_functions_file=true
+fi
 
 ln_cp_bak_question_f
 


### PR DESCRIPTION
4 main changes:

- Changes in wget to use tmp instead of local directory (sometimes it just said "no such file or directory")
- Delete an existing download of the repo in /tmp before cloning (avoids errors).
- cp instead of mv: avoids errors when moving (asking for overwriting a directory of something like that). Probably will need to delete the /tmp/gagvdot directory.
- Reinclude of functions: sometimes (i don't know why) the functions will just not be included (even though i had an "standard" zsh config). I made that hax to do it. Note that we need to put that variable to false to allow the functions to be included (they have a header guard).

I dind't test this throughly (since my working .sh dissapeared and i had to rewrite it) so it subtle (or no so subtle errors)